### PR TITLE
Add access level to user authentication response

### DIFF
--- a/src/endpoints/auth.py
+++ b/src/endpoints/auth.py
@@ -20,7 +20,7 @@ def loginUser():
     
     if foundedUser:
         if foundedUser.password == request.json['password']:
-            return jsonify({'message': 'Usuario autenticado', 'user_id': foundedUser.id}), 200
+            return jsonify({'message': 'Usuario autenticado', 'user_id': foundedUser.id, 'access_level': foundedUser.access_level}), 200
         else:
             return Response({'message':'Contraseña incorrecta'}), 401
         


### PR DESCRIPTION
Include the user's access level in the authentication response to provide more context about the user's permissions.