### PR TITLE
Add request printing for saveAttendance debugging

### DIFF
--- a/src/endpoints/attendances.py
+++ b/src/endpoints/attendances.py
@@ -192,6 +192,8 @@ def deleteAttendance(id):
 @token_required
 def saveAttendance():
 
+    print(request)
+
     newAttendance = None
     foundedAttendance = None
 


### PR DESCRIPTION
Include a print statement for the request in the saveAttendance function to aid in debugging.