### PR TITLE
Remove redundant serialization in tutor update endpoint response

### DIFF
--- a/src/endpoints/tutors.py
+++ b/src/endpoints/tutors.py
@@ -164,6 +164,6 @@ def update_tutor(id):
     
     serialized_tutor = tutor_schema.dump(founded_tutor)
 
-    response_data = json.dumps(serialized_tutor, ensure_ascii=False)
+    # response_data = json.dumps(serialized_tutor, ensure_ascii=False)
 
-    return jsonify(response_data), 201
+    return jsonify(serialized_tutor), 201


### PR DESCRIPTION
Eliminate unnecessary serialization of the response data in the tutor update endpoint, simplifying the response structure.