### PR TITLE
Remove redundant serialization in student endpoints

### DIFF
--- a/src/endpoints/students.py
+++ b/src/endpoints/students.py
@@ -100,9 +100,9 @@ def detele_student(id):
 
     serialized_student = student_schema.dump(founded_student)
 
-    response_data = json.dumps(serialized_student, ensure_ascii=False)
+    # response_data = json.dumps(serialized_student, ensure_ascii=False)
 
-    return jsonify(response_data), 201
+    return jsonify(serialized_student), 201
 
 
 # Definicionn endpoint creacion alumno
@@ -204,9 +204,9 @@ def update_student(id):
     
     serialized_student = student_schema.dump(founded_student)
 
-    response_data = json.dumps(serialized_student, ensure_ascii=False)
+    # response_data = json.dumps(serialized_student, ensure_ascii=False)
 
-    return jsonify(response_data), 201
+    return jsonify(serialized_student), 201
 
 
 # Definición endpoint para asociar tutores al alumno

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -48,9 +48,9 @@ class Student(db.Model):
         return f'{self.dni} - {self.surnames} {self.names}'
     
     #Funcion para serializar un alumno
-    def as_dict(self):
+    def as_dict(self, include_tutors=True):
 
-        tutors_list = [tutor.as_dict() for tutor in self.tutors]
+        tutors_list = [tutor.as_dict(include_students=False) for tutor in self.tutors] if include_tutors else []
 
         return {
             'id': self.id,


### PR DESCRIPTION
Eliminate unnecessary serialization in the responses of student retrieval and update endpoints. This simplifies the response handling.